### PR TITLE
API: remove renderer.invokeElementMethod question

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ A developer is perfectly able to use Angular to build applications without being
 ```
 
 * Why would you use renderer methods instead of using native element methods?
-* What is the  point of calling renderer.invokeElementMethod(rendererEl, methodName)?
 * How would you control size of an element on resize of the window in a component?
 * What would be a good use for NgZone service?
 * What are the bootstrap options for NgZone? Why would you use them? (Angular 5+)
@@ -132,7 +131,7 @@ let service = new DataService();
 
 * What is a structural directive?
 * How do you identify a structural directive in html?
-* When creating your own structural directives, how would you decide on hiding or removing an element? What would be the advantages or disadvantages of choosing one method rather than the other? 
+* When creating your own structural directives, how would you decide on hiding or removing an element? What would be the advantages or disadvantages of choosing one method rather than the other?
 
 #### Style Guide Questions:
 

--- a/api.md
+++ b/api.md
@@ -8,7 +8,6 @@ Binds a host element property (here, the CSS class valid) to a directive/compone
 
 
 * Why would you use renderer methods instead of using native element methods?
-* What is the  point of calling renderer.invokeElementMethod(rendererEl, methodName)?
 * How would you control size of an element on resize of the window in a component?
 * What would be a good use for NgZone service?
 
@@ -18,7 +17,7 @@ The most common use of this service is to optimize performance when starting a w
 
 - Provide your own `NgZone` instance.
 - `zone.js` - Use default `NgZone` which requires `Zone.js`.
-- `noop` - Use `NoopNgZone` which does nothing. You need to use async filter or manage change detection manually. 
+- `noop` - Use `NoopNgZone` which does nothing. You need to use async filter or manage change detection manually.
 
 source:[https://github.com/angular/angular/commit/344a5ca#diff-0ef0b3df44ffd7a42aab5233a1a3defc]
 


### PR DESCRIPTION
Hi!

The `invokeElementMethod(rendererEl, methodName)` was a `Renderer` method of Angular 2.x. Since Angular 4.x, a new `RendererV2` is in place and the old one is deprecated and this method doesn't exist anymore. The question has been remove to reflect the API change.

### note
Angular issue [here](https://github.com/angular/angular/issues/13818).

Have a nice day!